### PR TITLE
Add Hugging Face deployment support and improve key handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,14 +55,15 @@ Other notable files:
 3. **Install dependencies.**
    ```bash
    pip install --upgrade pip
-   pip install -r requirements.txt  # or install gradio google-genai google-auth python-dotenv
+   pip install -r requirements.txt
    ```
-   If `requirements.txt` is not available, install the packages shown in the comment.
 4. **Configure environment variables.**
    Update `gradio_playground/.env` (or export variables in your shell) with a
-   valid Gemini API key:
+   valid Gemini API key. Any of the following names are accepted:
    ```env
    GEMINI_API_KEY=your-real-api-key
+   # or, for Hugging Face Spaces secrets
+   GOOGLE_API_KEY=your-real-api-key
    ```
    The application uses [`python-dotenv`](https://pypi.org/project/python-dotenv/)
    to load values from `.env` automatically.
@@ -82,7 +83,25 @@ A lightweight regression script is provided for scenarios captured in
 `test_outputs/aistudio_tests_summary.json`:
 ```bash
 GEMINI_API_KEY=your-real-api-key python tests/run_aistudio_tests.py
+# or equivalently
+GOOGLE_API_KEY=your-real-api-key python tests/run_aistudio_tests.py
 ```
+
+## Deploying to Hugging Face Spaces
+1. **Create a new Gradio Space.** Choose the “Gradio” SDK and link it to a Git
+   repository (public or private depending on your needs).
+2. **Push the project files.** The provided `app.py` exports the `demo` object
+   expected by Spaces, and `requirements.txt` lists the runtime dependencies.
+3. **Configure secrets.** Navigate to *Settings → Secrets* and add
+   `GOOGLE_API_KEY` (or any other supported name listed above) with your Gemini
+   API key.
+4. **Select hardware (optional).** Free CPU tiers are sufficient for testing.
+   Ensure the Space type allows outbound internet access so requests can reach
+   the Gemini API.
+5. **Trigger a build.** When the Space restarts it installs dependencies from
+   `requirements.txt` and launches the Gradio app defined in `app.py`.
+6. **Smoke test the UI.** Exercise several tabs, verify bilingual switching,
+   and ensure generated assets appear under the `playground_outputs/` directory.
 
 ## Localization Workflow
 - All UI strings reside in `gradio_playground/translations_map.json`.

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -53,13 +53,15 @@ gradio_playground/
 3. **安裝依賴套件。**
    ```bash
    pip install --upgrade pip
-   pip install -r requirements.txt  # 或安裝 gradio google-genai google-auth python-dotenv
+   pip install -r requirements.txt
    ```
-   若沒有 `requirements.txt`，請依註解中的套件清單安裝。
 4. **設定環境變數。**
-   在 `gradio_playground/.env`（或直接在終端機）填入有效的 API 金鑰：
+   在 `gradio_playground/.env`（或直接在終端機）填入有效的 API 金鑰，系統會依序
+   嘗試以下變數名稱：
    ```env
    GEMINI_API_KEY=你的真實金鑰
+   # 或（適用於 Hugging Face Spaces Secrets）
+   GOOGLE_API_KEY=你的真實金鑰
    ```
    應用程式會透過 [`python-dotenv`](https://pypi.org/project/python-dotenv/)
    自動載入 `.env` 中的設定。
@@ -79,7 +81,22 @@ Gradio 會啟用背景佇列並開啟本機介面，所有產出檔案將寫入�
 情境的快速驗證：
 ```bash
 GEMINI_API_KEY=你的真實金鑰 python tests/run_aistudio_tests.py
+# 或
+GOOGLE_API_KEY=你的真實金鑰 python tests/run_aistudio_tests.py
 ```
+
+## 部署至 Hugging Face Spaces
+1. **建立新的 Gradio Space。** 選擇「Gradio」SDK，並視需求設定公開或私人。
+2. **推送專案檔案。** `app.py` 已曝光 Gradio 所需的 `demo` 物件，
+   `requirements.txt` 則列出執行時需要的套件。
+3. **設定密鑰。** 進入「Settings → Secrets」，新增 `GOOGLE_API_KEY`
+   （或其他支援的變數名稱）並填入 Gemini API 金鑰。
+4. **選擇硬體（可選）。** 免費 CPU 即可應付一般測試，需確保 Space 具有外網連線
+   以便呼叫 Gemini API。
+5. **觸發建置。** Spaces 會在重新啟動時依 `requirements.txt` 安裝套件，並執行
+   `app.py` 載入 Gradio 應用。
+6. **驗證介面。** 測試多個分頁、確認語言切換正常，以及輸出檔案是否寫入
+   `playground_outputs/` 目錄。
 
 ## 在地化流程
 - 所有介面字詞集中於 `gradio_playground/translations_map.json`。

--- a/app.py
+++ b/app.py
@@ -1,0 +1,10 @@
+"""Entry point for Hugging Face Spaces deployment."""
+
+from gradio_playground.ui import build_demo
+
+
+demo = build_demo()
+
+
+if __name__ == "__main__":
+    demo.launch()

--- a/gradio_playground/config.py
+++ b/gradio_playground/config.py
@@ -1,7 +1,9 @@
-﻿from __future__ import annotations
+from __future__ import annotations
 
 import os
+from functools import lru_cache
 from pathlib import Path
+from typing import Iterable, Optional
 
 from dotenv import load_dotenv
 
@@ -23,11 +25,60 @@ for env_path in ENV_PATHS:
         load_dotenv(env_path, override=False)
 load_dotenv(override=False)
 
-API_KEY = os.getenv("GEMINI_API_KEY")
-if not API_KEY:
-    raise RuntimeError("Set GEMINI_API_KEY in .env or the shell environment before launching the playground.")
+API_KEY_ENV_CANDIDATES: Iterable[str] = (
+    "GEMINI_API_KEY",
+    "GOOGLE_API_KEY",
+    "GOOGLE_GENAI_API_KEY",
+    "GENAI_API_KEY",
+)
 
-CLIENT = genai.Client(api_key=API_KEY)
+
+def _find_api_key() -> Optional[str]:
+    for env_name in API_KEY_ENV_CANDIDATES:
+        raw_value = os.getenv(env_name)
+        if raw_value and raw_value.strip():
+            return raw_value.strip()
+    return None
+
+
+def get_api_key(*, raise_error: bool = True) -> str:
+    """Return the configured Gemini API key.
+
+    Hugging Face Spaces typically expose secrets as environment variables.  To
+    support that workflow we check multiple candidate names, including
+    ``GOOGLE_API_KEY`` which aligns with the default secret naming convention
+    used in Spaces.
+    """
+
+    api_key = _find_api_key()
+    if api_key:
+        return api_key
+    if not raise_error:
+        return ""
+    candidates = ", ".join(f"`{name}`" for name in API_KEY_ENV_CANDIDATES)
+    raise RuntimeError(
+        "No Google Gemini API key found. Set one of the environment variables "
+        f"{candidates}. When deploying to Hugging Face Spaces, configure the "
+        "secret in the Space settings so it is available as an environment "
+        "variable before launching the app."
+    )
+
+
+@lru_cache(maxsize=1)
+def get_client() -> genai.Client:
+    """Return a cached Gemini client instance."""
+
+    return genai.Client(api_key=get_api_key())
+
+
+class _ClientProxy:
+    """Lazily create the Google Gemini client on first access."""
+
+    def __getattr__(self, name: str):
+        return getattr(get_client(), name)
+
+
+CLIENT = _ClientProxy()
 
 SUMMARY_PATH = PROJECT_ROOT / "test_outputs" / "aistudio_tests_summary.json"
 PLAYGROUND_OUTPUT_DIR = PROJECT_ROOT / "playground_outputs"
@@ -50,5 +101,7 @@ __all__ = [
     "SAMPLE_IMAGE",
     "SAMPLE_REPORT",
     "SUMMARY_PATH",
+    "get_api_key",
+    "get_client",
     "types",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+gradio>=4.44.0,<5.0.0
+google-genai>=0.4.1
+google-auth>=2.29.0
+python-dotenv>=1.0.1

--- a/tests/run_aistudio_tests.py
+++ b/tests/run_aistudio_tests.py
@@ -2,7 +2,6 @@
 import base64
 import mimetypes
 import json
-import os
 import sys
 from pathlib import Path
 from typing import Any, Dict, Optional, Tuple
@@ -11,6 +10,8 @@ from dotenv import load_dotenv
 from google import genai
 from google.genai import types
 from google.genai.errors import ClientError
+
+from gradio_playground.config import get_api_key
 
 
 class BlockedTest(Exception):
@@ -24,11 +25,7 @@ if hasattr(sys.stdout, "reconfigure"):
     sys.stdout.reconfigure(encoding="utf-8")
 
 load_dotenv()
-API_KEY = os.getenv("GEMINI_API_KEY")
-if not API_KEY:
-    raise RuntimeError("GEMINI_API_KEY is not set; load it in .env before running.")
-
-client = genai.Client(api_key=API_KEY)
+client = genai.Client(api_key=get_api_key())
 
 results: list[Dict[str, Any]] = []
 


### PR DESCRIPTION
## Summary
- add a Hugging Face-friendly `app.py` launcher and project `requirements.txt`
- enhance `config.py` to support multiple API key environment variables and lazily create the Gemini client
- refresh docs and tests to reflect the new configuration workflow for Spaces deployment

## Testing
- python -m compileall gradio_playground tests app.py

------
https://chatgpt.com/codex/tasks/task_e_68d409128950833298f58e801e90cbe8