### PR TITLE
Fix dependency conflict in requirements

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-gradio>=4.44.0,<5.0.0
-google-genai>=0.4.1
+gradio>=5.47.0,<6.0.0
+google-genai>=1.0.0
 google-auth>=2.29.0
 python-dotenv>=1.0.1


### PR DESCRIPTION
## Summary
- update gradio to 5.47.0 to align with newer gradio-client that supports websockets>=13
- raise google-genai minimum version to 1.0.0 to match available releases and resolve dependency conflict

## Testing
- `pip install --no-cache-dir -r requirements.txt`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68d4411214448332bd77fbd63d3da2b8